### PR TITLE
Fixed External Snapshot Links

### DIFF
--- a/src/components/Proposals/SnapshotProposalsList.tsx
+++ b/src/components/Proposals/SnapshotProposalsList.tsx
@@ -1,6 +1,5 @@
 import { ButtonLink, TimeDisplay, useCountdown } from '@pooltogether/react-components'
 import { useTranslation } from 'next-i18next'
-import Link from 'next/link'
 import React from 'react'
 import {
   EmptyProposalsList,
@@ -49,11 +48,13 @@ const SnapshotProposalItem = (props) => {
         </div>
         <SnapshotProposalCountDown end={end} />
       </div>
-      <Link href={`${POOLPOOL_SNAPSHOT_URL}/proposal/${id}`}>
-        <ButtonLink target='_blank' rel='noopener noreferrer'>
-          {t('voteNow')}
-        </ButtonLink>
-      </Link>
+      <ButtonLink
+        href={`${POOLPOOL_SNAPSHOT_URL}/proposal/${id}`}
+        target='_blank'
+        rel='noopener noreferrer'
+      >
+        {t('voteNow')}
+      </ButtonLink>
     </ProposalItemContainer>
   )
 }


### PR DESCRIPTION
The `<Link>` component was being used for an external link on the snapshots page; thus buttons weren't working.

Now they do :D